### PR TITLE
Reserve mission

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -71,7 +71,9 @@ hr {
   cursor: pointer;
 }
 
-table, th, td {
+table,
+th,
+td {
   border: 1px solid black;
   border-collapse: collapse;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -70,3 +70,8 @@ hr {
   border-radius: 0.5rem;
   cursor: pointer;
 }
+
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ function App() {
         <Route path="/" element={<Rockets />} />
         <Route path="/missions" element={<Missions />} />
         <Route path="/myprofile" element={<Myprofile />} />
+        <Route path="*" element={<Rockets />} />
       </Routes>
     </Router>
   );

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,18 +1,21 @@
-// import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   NavLink,
 } from 'react-router-dom';
 import logo from '../assets/planet.png';
-// import { FetchData } from '../redux/missions/MissionReducer';
+import { FetchData } from '../redux/missions/MissionReducer';
 
 const Header = () => {
   const activeStyle = {
     textDecoration: 'underline',
   };
-  // const dispatch = useDispatch();
-  // const loadMission = () => {
-  //   dispatch(FetchData());
-  // };
+  const dispatch = useDispatch();
+  const myState = useSelector((state) => state.missionReducer);
+  const loadMission = () => {
+    if (myState.length === 0) {
+      dispatch(FetchData());
+    }
+  };
 
   return (
     <header>
@@ -35,7 +38,7 @@ const Header = () => {
             <NavLink
               to="missions"
               style={({ isActive }) => (isActive ? activeStyle : undefined)}
-              // onClick={loadMission}
+              onClick={loadMission}
             >
               Missions
             </NavLink>

--- a/src/components/missions/MissionItem.js
+++ b/src/components/missions/MissionItem.js
@@ -1,25 +1,32 @@
 // import { useSelector } from "react-redux";
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { JoinMission } from '../../redux/missions/MissionReducer';
 
-const MissionItem = ({ id, mission, description }) => {
+const MissionItem = ({
+  id, mission, description, reserved,
+}) => {
   // const myState = useSelector(state => state);
   // console.log(myState);
+  const dispatch = useDispatch();
   const handleJoin = (e) => {
     const myId = e.target.className;
-    console.log(myId);
+    dispatch(JoinMission(myId));
   };
   return (
     <tr>
       <td>{mission}</td>
       <td>{description}</td>
-      <td>NOT A MEMBER</td>
+      <td>
+        { reserved ? (<span> Active Member</span>) : (<span> NOT A MEMBER</span>)}
+      </td>
       <td>
         <button
           type="button"
           onClick={handleJoin}
           className={id}
         >
-          Join Mission
+          { reserved ? 'Leave Mission' : 'Join Mission'}
         </button>
       </td>
     </tr>
@@ -30,6 +37,7 @@ MissionItem.propTypes = {
   id: PropTypes.string.isRequired,
   mission: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  reserved: PropTypes.string.isRequired,
 };
 
 export default MissionItem;

--- a/src/components/missions/MissionItem.js
+++ b/src/components/missions/MissionItem.js
@@ -25,6 +25,10 @@ const MissionItem = ({
           type="button"
           onClick={handleJoin}
           className={id}
+          style={{
+            color: reserved ? 'red' : 'black',
+            border: reserved ? '1px solid red' : '1px solid black',
+          }}
         >
           { reserved ? 'Leave Mission' : 'Join Mission'}
         </button>

--- a/src/components/missions/MissionItem.js
+++ b/src/components/missions/MissionItem.js
@@ -1,4 +1,3 @@
-// import { useSelector } from "react-redux";
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { JoinMission } from '../../redux/missions/MissionReducer';
@@ -6,8 +5,6 @@ import { JoinMission } from '../../redux/missions/MissionReducer';
 const MissionItem = ({
   id, mission, description, reserved,
 }) => {
-  // const myState = useSelector(state => state);
-  // console.log(myState);
   const dispatch = useDispatch();
   const handleJoin = (e) => {
     const myId = e.target.className;

--- a/src/components/missions/MissionList.js
+++ b/src/components/missions/MissionList.js
@@ -1,17 +1,17 @@
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { FetchData } from '../../redux/missions/MissionReducer';
+// import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+// import { FetchData } from '../../redux/missions/MissionReducer';
 import MissionItem from './MissionItem';
 
 const MissionList = () => {
-  const dispatch = useDispatch();
+  // const dispatch = useDispatch();
+  const myState = useSelector((state) => state.missionReducer);
+  // useEffect(() => {
+  //   if (myState.lenght === 0) {
+  //     dispatch(FetchData());
+  //   }
+  // }, []);
 
-  useEffect(() => {
-    dispatch(FetchData());
-  }, []);
-
-  const myState = useSelector((state) => state);
-  console.log(myState);
   return (
     <table>
       <tr>
@@ -26,6 +26,7 @@ const MissionList = () => {
           id={element.MissionId}
           mission={element.MissionName}
           description={element.description}
+          reserved={element.reserved}
         />
       ))}
       <MissionItem />

--- a/src/components/missions/MissionList.js
+++ b/src/components/missions/MissionList.js
@@ -14,22 +14,25 @@ const MissionList = () => {
 
   return (
     <table>
-      <tr>
-        <th>Mission</th>
-        <th>Description</th>
-        <th>Status</th>
-        <th>Join</th>
-      </tr>
-      {myState.map((element) => (
-        <MissionItem
-          key={element.MissionId}
-          id={element.MissionId}
-          mission={element.MissionName}
-          description={element.description}
-          reserved={element.reserved}
-        />
-      ))}
-      <MissionItem />
+      <thead>
+        <tr>
+          <th>Mission</th>
+          <th>Description</th>
+          <th>Status</th>
+          <th>Join</th>
+        </tr>
+      </thead>
+      <tbody>
+        {myState.map((element) => (
+          <MissionItem
+            key={element.MissionId}
+            id={element.MissionId}
+            mission={element.MissionName}
+            description={element.description}
+            reserved={element.reserved}
+          />
+        ))}
+      </tbody>
     </table>
   );
 };

--- a/src/components/missions/MissionList.js
+++ b/src/components/missions/MissionList.js
@@ -1,16 +1,8 @@
-// import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-// import { FetchData } from '../../redux/missions/MissionReducer';
 import MissionItem from './MissionItem';
 
 const MissionList = () => {
-  // const dispatch = useDispatch();
   const myState = useSelector((state) => state.missionReducer);
-  // useEffect(() => {
-  //   if (myState.lenght === 0) {
-  //     dispatch(FetchData());
-  //   }
-  // }, []);
 
   return (
     <table>

--- a/src/pages/Myprofile.js
+++ b/src/pages/Myprofile.js
@@ -1,5 +1,9 @@
 const Myprofile = () => (
-  <div>My profile page</div>
+  <div>
+    <h2>
+      My Missions
+    </h2>
+  </div>
 );
 
 export default Myprofile;

--- a/src/redux/missions/MissionReducer.js
+++ b/src/redux/missions/MissionReducer.js
@@ -1,6 +1,5 @@
 // Actions
 const JOIN = 'missions/missionReducer/JOIN';
-// const LEAVE = 'missions/missionReducer/LEAVE';
 const FETCH_MISSION = 'mission/missionReducer/FETCH_MISSION';
 
 const missionUrl = 'https://api.spacexdata.com/v3/missions';
@@ -8,7 +7,6 @@ const missionUrl = 'https://api.spacexdata.com/v3/missions';
 export const FetchData = () => async (dispatch) => {
   const response = await fetch(missionUrl);
   const data = await response.json();
-  console.log(data);
   const data2 = [];
   data.forEach((element) => {
     data2.push({

--- a/src/redux/missions/MissionReducer.js
+++ b/src/redux/missions/MissionReducer.js
@@ -33,7 +33,7 @@ export const missionReducer = (state = [], action = {}) => {
   switch (action.type) {
     case JOIN: {
       const newState = state.map((element) => {
-        if (element.mission_id !== action.payload) {
+        if (element.MissionId !== action.payload) {
           return element;
         }
         if (element.reserved === true) {
@@ -44,7 +44,7 @@ export const missionReducer = (state = [], action = {}) => {
       return newState;
     }
     case FETCH_MISSION:
-      return [...state, ...action.payload];
+      return action.payload;
     default:
       return state;
   }


### PR DESCRIPTION
I implemented next features:

- When a user clicks the "Join Mission" button, action needs to be dispatched to update the store. You need to get the ID of the selected mission and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all missions, but the selected mission will have an extra key reserved with its value set to true. 
- Follow the same logic as with the "Join mission" - but you need to set the reserved key to false.
- Dispatch these actions upon click on the corresponding buttons.
- Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).
